### PR TITLE
Add support for new config values. apache_http_addendum and apache_htt…

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -171,7 +171,7 @@ options:
       .
         juju-postgresql-0
       .
-      If you're running multiple environments with the same services in them
+      If you are running multiple environments with the same services in them
       this allows you to differentiate between them.
   nagios_check_http_params:
     default: "-H localhost -I 127.0.0.1 -u '/' -e 200,301,302"
@@ -217,3 +217,15 @@ options:
     description: |
        Connect timeout configuration in ms for haproxy, used in HA
        configurations. If not provided, default value of 5000ms is used.
+  apache_http_addendum:
+    type: string
+    default: ''
+    description: |
+      Extra stanzas to be inserted into the HTTP virtual host configuration.
+      May be used,for example, to specify rewrite rules.
+  apache_https_addendum:
+    type: string
+    default: ''
+    description: |
+      Extra stanzas to be inserted into the HTTPS virtual host configuration.
+      May be used,for example, to specify rewrite rules.

--- a/hooks/horizon_contexts.py
+++ b/hooks/horizon_contexts.py
@@ -172,7 +172,8 @@ class ApacheContext(OSContextGenerator):
         ''' Grab cert and key from configuraton for SSL config '''
         ctxt = {
             'http_port': 70,
-            'https_port': 433
+            'https_port': 433,
+            'apache_http_addendum': config("apache_http_addendum"),
         }
         return ctxt
 
@@ -200,6 +201,7 @@ class ApacheSSLContext(OSContextGenerator):
             ctxt = {
                 'ssl_configured': False,
             }
+        ctxt['apache_https_addendum'] = config("apache_https_addendum")
         return ctxt
 
 

--- a/templates/default
+++ b/templates/default
@@ -29,4 +29,6 @@
 
         CustomLog ${APACHE_LOG_DIR}/access.log combined
 
+{{ apache_http_addendum }}
+
 </VirtualHost>

--- a/templates/default-ssl
+++ b/templates/default-ssl
@@ -46,5 +46,7 @@
                 downgrade-1.0 force-response-1.0
         BrowserMatch "MSIE [17-9]" ssl-unclean-shutdown
 
+{{ apache_https_addendum }}
+
     </VirtualHost>
 </IfModule>


### PR DESCRIPTION
apache_http_addendum and apache_https_addendum allow the charm to be configured to add apache configuration slugs, like RewriteRules. Required for our work embedding Juju GUI.
